### PR TITLE
ECA-2245-adds-nested-queries

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -522,9 +522,10 @@ module Searchkick
     def build_nested(bool, filters, query=[])
       nested = filters.select{|f| f.include?(:nested) }.first
       if nested.present?
+        return bool if bool.dig(:must, :match_all)
         nested = nested.delete(:nested)
         filters.reject!(&:none?)
-        storage = bool.dig(:must, :dis_max, :queries) || bool.dig(:must, :match_all)
+        storage = bool.dig(:must, :dis_max, :queries)
         storage <<
         {
           nested:

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -525,20 +525,23 @@ module Searchkick
     def nested_query(nested, filters)
       nested = nested.delete(:nested)
       filters.reject!(&:none?)
+
+      # find next nested document and recursively build
+      # query again if one exists
       additional_nested = filters.select{|f| f.include?(:nested) }.first
       query = additional_nested ? nested_query(additional_nested, filters) : nested[:query]
 
-      if query.class == Array
+      if query.is_a?(Array)
         query = { bool:
                   { must: query }
                 }
       end
 
       { nested:
-          {
-            path: nested[:path],
-            query: query
-          }
+        {
+          path: nested[:path],
+          query: query
+        }
       }
     end
 
@@ -866,7 +869,7 @@ module Searchkick
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
         elsif field == :nested
-          if value.class == Array
+          if value.is_a?(Array)
             value.each do |sub_value|
               nested_filters(sub_value, filters)
             end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -527,17 +527,17 @@ module Searchkick
       filters.reject!(&:none?)
       additional_nested = filters.select{|f| f.include?(:nested) }.first
       query = additional_nested ? nested_query(additional_nested, filters) : nested[:query]
-      q = if query.class == Array
+
+      query = if query.class == Array
         { bool:
           { must: query }
         }
-      else
-        query
       end
+
       { nested:
           {
             path: nested[:path],
-            query: q
+            query: query
           }
       }
     end
@@ -866,9 +866,9 @@ module Searchkick
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
         elsif field == :nested
           nested_where = {}
-          value[:where].each do |k,v|
-            key = k != :nested ? "#{value[:path]}.#{k}" : k
-            nested_where.merge!({key => v})
+          value[:where].each do |key, val|
+            key = "#{value[:path]}.#{key}" if key != :nested
+            nested_where.merge!({key => val})
           end
           filters << {
             nested: {

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -578,6 +578,7 @@ module Searchkick
           }
         }
       end
+
       query
     end
 

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -179,154 +179,187 @@ class SqlTest < Minitest::Test
     store [
       {name: 'Amazon', employees: [
         Employee.create(name: 'Jim', age: 22, reviews: [
-          Review.create(name: 'Review A', stars: 3, comments: [Comment.create(status: 'denied')])
+          Review.create(name: 'Review A', stars: 3, comments: [
+            Comment.create(status: 'denied', message: 'bad')
+          ])
         ]),
         Employee.create(name: 'Jamie', age: 32, reviews: [
-          Review.create(name: 'Review C', stars: 5, comments: [Comment.create(status: 'denied')])
+          Review.create(name: 'Review C', stars: 5, comments: [
+            Comment.create(status: 'denied', message: 'bad')
+          ])
         ])
       ]},
       {name: 'Costco', employees: [
         Employee.create(name: 'Bob', age: 34, reviews: [
-          Review.create(name: 'Review B', stars: 2, comments: [Comment.create(status: 'approved')])
+          Review.create(name: 'Review B', stars: 2, comments: [
+            Comment.create(status: 'approved', message: 'good')
+          ])
         ])
       ]},
       {name: 'Walmart', employees: [
         Employee.create(name: 'Karen', age: 19, reviews: [
-          Review.create(name: 'Review C', stars: 4, comments: [Comment.create(status: 'approved')])
+          Review.create(name: 'Review C', stars: 4, comments: [
+            Comment.create(status: 'approved', message: 'good'),
+            Comment.create(status: 'denied', message: 'good')
+          ])
         ])
       ]}
     ], Store
 
-    assert_search "store", ["Amazon"], {where: {
-                                         name: 'Amazon',
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             'name' => 'Jim'
-                                           }
-                                         }
-                                       }
-                                     }, Store
-
-    assert_search "store", [], {where: {
-                                         name: 'Amazon',
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             'name' => 'Karen',
-                                             'age' => 1,
-                                           }
-                                         }
-                                       }
-                                     }, Store
-
-    assert_search "store", ['Costco'], {where: {
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             'name' => 'Bob',
-                                             'age' => 34,
-                                           }
-                                         }
-                                       }
-                                     }, Store
-
-
-    assert_search "store", ['Costco'], {where: {
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             nested: {
-                                               path: 'employees.reviews',
-                                               where: {
-                                                 name: 'Review B'
-                                               }
+    assert_search "store", ["Amazon"], { where: {
+                                           name: 'Amazon',
+                                           nested: {
+                                             path: 'employees',
+                                             where: {
+                                               'name' => 'Jim'
                                              }
                                            }
                                          }
-                                       }
-                                     }, Store
+                                       }, Store
 
-    assert_search "store", ['Amazon', 'Walmart'], {where: {
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             nested: {
-                                               path: 'employees.reviews',
-                                               where: {
-                                                 name: 'Review C'
-                                               }
-                                             }
-                                           }
-                                         }
-                                       }
-                                     }, Store
-
-
-    # With all
-    result = Store.search "*", {where:
-                                 {nested: {
-                                   path: 'employees',
-                                   where: {
-                                     name: 'Jamie'
-                                   }
-                                 }}
-                               }
-
-    assert_equal result.results.first.name, 'Amazon'
-
-    result = Store.search "*", {where:
-                                 {nested: {
-                                   path: 'employees',
-                                   where: {
-                                     name: 'Bob'
-                                   }
-                                 }}
-                               }
-
-    assert_equal result.results.first.name, 'Costco'
-
-    # With range
-    result = Store.search "*", {where:
-                                 {nested: {
-                                   path: 'employees',
-                                   where: {
-                                     age: {
-                                       lt: 20
+    assert_search "store", [], { where: {
+                                   name: 'Amazon',
+                                   nested: {
+                                     path: 'employees',
+                                     where: {
+                                       'name' => 'Karen',
+                                       'age' => 1,
                                      }
                                    }
-                                 }}
-                               }
+                                 }
+                               }, Store
 
-    assert_equal result.results.first.name, 'Walmart'
+    assert_search "store", ['Costco'], { where: {
+                                           nested: {
+                                             path: 'employees',
+                                             where: {
+                                               'name' => 'Bob',
+                                               'age' => 34,
+                                             }
+                                           }
+                                         }
+                                       }, Store
 
-    assert_search "store", ['Walmart'], {where: {
-                                         nested: {
-                                           path: 'employees',
-                                           where: {
-                                             age: {
-                                               lt: 20
-                                             },
-                                             nested: {
-                                               path: 'employees.reviews',
-                                               where: {
-                                                 name: 'Review C',
-                                                 stars: {
-                                                   gt: 3
-                                                 },
-                                                 nested: {
-                                                   path: 'employees.reviews.comments',
-                                                   where: {
-                                                     status: 'approved'
-                                                   }
+
+    assert_search "store", ['Costco'], { where: {
+                                           nested: {
+                                             path: 'employees',
+                                             where: {
+                                               nested: {
+                                                 path: 'employees.reviews',
+                                                 where: {
+                                                   name: 'Review B'
                                                  }
                                                }
                                              }
                                            }
                                          }
-                                       }
-                                     }, Store
+                                       }, Store
 
+    assert_search "store", ['Amazon', 'Walmart'], { where: {
+                                                      nested: {
+                                                        path: 'employees',
+                                                        where: {
+                                                          nested: {
+                                                            path: 'employees.reviews',
+                                                            where: {
+                                                              name: 'Review C'
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }, Store
+
+
+    # With all
+    result = Store.search "*", { where: {
+                                   nested: {
+                                     path: 'employees',
+                                     where: {
+                                       name: 'Jamie'
+                                     }
+                                   }
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Amazon'
+
+    result = Store.search "*", { where: {
+                                   nested: {
+                                     path: 'employees',
+                                     where: {
+                                       name: 'Bob'
+                                     }
+                                   }
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Costco'
+
+    # With range
+    result = Store.search "*", { where: {
+                                   nested: {
+                                     path: 'employees',
+                                     where: {
+                                       age: {
+                                         lt: 20
+                                       }
+                                     }
+                                   }
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Walmart'
+
+    # Deeply nested
+    assert_search "store", ['Walmart'], { where: {
+                                            nested: {
+                                              path: 'employees',
+                                              where: {
+                                                age: {
+                                                  lt: 20
+                                                },
+                                                nested: {
+                                                  path: 'employees.reviews',
+                                                  where: {
+                                                    name: 'Review C',
+                                                    stars: {
+                                                      gt: 3
+                                                    },
+                                                    nested: {
+                                                      path: 'employees.reviews.comments',
+                                                      where: {
+                                                        status: 'approved'
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }, Store
+
+    assert_search "store", ['Costco', 'Walmart'], { where: {
+                                                      nested: {
+                                                       path: 'employees',
+                                                       where: {
+                                                         nested: {
+                                                           path: 'employees.reviews',
+                                                           where: {
+                                                             nested: {
+                                                               path: 'employees.reviews.comments',
+                                                               where: {
+                                                                 status: 'approved',
+                                                                 message: 'good'
+                                                               }
+                                                             }
+                                                           }
+                                                         }
+                                                       }
+                                                     }
+                                                   }
+                                                 }, Store
   end
 
   # other tests

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -214,6 +214,7 @@ class SqlTest < Minitest::Test
       ]}
     ], Store
 
+    # Single nested
     assert_search "store", ["Amazon"], { where: {
                                            name: 'Amazon',
                                            nested: {
@@ -249,6 +250,7 @@ class SqlTest < Minitest::Test
                                        }, Store
 
 
+    # multiple nested
     assert_search "store", ['Costco'], { where: {
                                            nested: {
                                              path: 'employees',
@@ -294,6 +296,7 @@ class SqlTest < Minitest::Test
                                 }
                               }, Store
 
+    # Nested sibling documents
     assert_search "store", ['Walmart'], { where: {
                                           nested: {
                                             path: 'employees',

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -159,12 +159,12 @@ class SqlTest < Minitest::Test
 
   def test_nested_one_level
     store [
-      {name: 'ProductA', aisle: 1, reviews: [Review.create(name: 'Review A')]},
-      {name: 'ProductB', aisle: 2, reviews: [Review.create(name: 'Review B')]},
-      {name: 'ProductC', aisle: 3, reviews: [Review.create(name: 'Review C')]}
-    ], Product
+      {name: 'Jim', reviews: [Review.create(name: 'Review A')]},
+      {name: 'Bob', reviews: [Review.create(name: 'Review B')]},
+      {name: 'Karen', reviews: [Review.create(name: 'Review C')]}
+    ], Employee
 
-    assert_search "product", ['ProductB'], {where: {
+    assert_search "Employee", ['Bob'], {where: {
                                                  nested: {
                                                    path: 'reviews',
                                                    where: {
@@ -172,23 +172,22 @@ class SqlTest < Minitest::Test
                                                    }
                                                  }
                                                }
-                                           }, Product
+                                           }, Employee
   end
 
   def test_where_nested
     store [
-      {name: 'Amazon', products: [Product.create(name: 'ProductA', aisle: 1, reviews: [Review.create(name: 'Review A')])]},
-      {name: 'Costco', products: [Product.create(name: 'ProductB', aisle: 2, reviews: [Review.create(name: 'Review B')])]},
-      {name: 'Walmart', products: [Product.create(name: 'ProductC', aisle: 3, reviews: [Review.create(name: 'Review C')])]}
+      {name: 'Amazon', employees: [Employee.create(name: 'Jim', age: 22, reviews: [Review.create(name: 'Review A')])]},
+      {name: 'Costco', employees: [Employee.create(name: 'Bob', age: 34, reviews: [Review.create(name: 'Review B')])]},
+      {name: 'Walmart', employees: [Employee.create(name: 'Karen', age: 19, reviews: [Review.create(name: 'Review C')])]}
     ], Store
 
     assert_search "store", ["Amazon"], {where: {
                                          name: 'Amazon',
                                          nested: {
-                                           path: 'products',
+                                           path: 'employees',
                                            where: {
-                                             'name' => 'ProductA',
-                                             'aisle' => 1,
+                                             'name' => 'Jim'
                                            }
                                          }
                                        }
@@ -197,10 +196,10 @@ class SqlTest < Minitest::Test
     assert_search "store", [], {where: {
                                          name: 'Amazon',
                                          nested: {
-                                           path: 'products',
+                                           path: 'employees',
                                            where: {
-                                             'name' => 'ProductB',
-                                             'aisle' => 1,
+                                             'name' => 'Karen',
+                                             'age' => 1,
                                            }
                                          }
                                        }
@@ -208,10 +207,10 @@ class SqlTest < Minitest::Test
 
     assert_search "store", ['Costco'], {where: {
                                          nested: {
-                                           path: 'products',
+                                           path: 'employees',
                                            where: {
-                                             'name' => 'ProductB',
-                                             'aisle' => 2,
+                                             'name' => 'Bob',
+                                             'age' => 34,
                                            }
                                          }
                                        }
@@ -220,10 +219,10 @@ class SqlTest < Minitest::Test
 
     assert_search "store", ['Costco'], {where: {
                                          nested: {
-                                           path: 'products',
+                                           path: 'employees',
                                            where: {
                                              nested: {
-                                               path: 'products.reviews',
+                                               path: 'employees.reviews',
                                                where: {
                                                  name: 'Review B'
                                                }

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -182,11 +182,15 @@ class SqlTest < Minitest::Test
           Review.create(name: 'Review A', stars: 3, comments: [
             Comment.create(status: 'denied', message: 'bad')
           ])
+        ], time_cards: [
+          TimeCard.create(hours: 5)
         ]),
         Employee.create(name: 'Jamie', age: 32, reviews: [
           Review.create(name: 'Review C', stars: 5, comments: [
             Comment.create(status: 'denied', message: 'bad')
           ])
+        ], time_cards: [
+          TimeCard.create(hours: 8)
         ])
       ]},
       {name: 'Costco', employees: [
@@ -194,6 +198,8 @@ class SqlTest < Minitest::Test
           Review.create(name: 'Review B', stars: 2, comments: [
             Comment.create(status: 'approved', message: 'good')
           ])
+        ], time_cards: [
+          TimeCard.create(hours: 7)
         ])
       ]},
       {name: 'Walmart', employees: [
@@ -202,6 +208,8 @@ class SqlTest < Minitest::Test
             Comment.create(status: 'approved', message: 'good'),
             Comment.create(status: 'denied', message: 'good')
           ])
+        ], time_cards: [
+          TimeCard.create(hours: 12)
         ])
       ]}
     ], Store
@@ -272,18 +280,39 @@ class SqlTest < Minitest::Test
                                                   }, Store
 
     assert_search "store", [], { where: {
+                                  nested: {
+                                    path: 'employees',
+                                    where: {
+                                      nested: {
+                                        path: 'employees.reviews',
+                                        where: {
+                                          name: 'Review F'
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }, Store
+
+    assert_search "store", ['Walmart'], { where: {
                                           nested: {
                                             path: 'employees',
                                             where: {
-                                              nested: {
-                                                path: 'employees.reviews',
-                                                where: {
-                                                  name: 'Review F'
-                                                }
+                                              nested: [
+                                                {
+                                                  path: 'employees.reviews',
+                                                  where: {
+                                                    name: 'Review C'
+                                                  }
+                                                }, {
+                                                  path: 'employees.time_cards',
+                                                  where: {
+                                                    hours: {gt: 10}
+                                                  }
+                                                }]
                                               }
                                             }
                                           }
-                                        }
                                       }, Store
 
     # With all
@@ -374,6 +403,7 @@ class SqlTest < Minitest::Test
                                                      }
                                                    }
                                                  }, Store
+
   end
 
   def test_nested_json

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -157,6 +157,49 @@ class SqlTest < Minitest::Test
     assert_search "frozen", ["Product A"], {fields: ["aisle.name"]}, Speaker
   end
 
+  def test_where_nested
+    store [
+      {name: 'Amazon', products: [Product.create(name: 'ProductA', aisle: 1)]},
+      {name: 'Costco', products: [Product.create(name: 'ProductB', aisle: 2)]},
+      {name: 'Walmart', products: [Product.create(name: 'ProductC', aisle: 3)]}
+    ], Store
+
+    assert_search "store", ["Amazon"], {where: {
+                                         name: 'Amazon',
+                                         nested: {
+                                           path: 'products',
+                                           where: {
+                                             'name' => 'ProductA',
+                                             'aisle' => 1,
+                                           }
+                                         }
+                                       }
+                                     }, Store
+
+    assert_search "store", [], {where: {
+                                         name: 'Amazon',
+                                         nested: {
+                                           path: 'products',
+                                           where: {
+                                             'name' => 'ProductB',
+                                             'aisle' => 1,
+                                           }
+                                         }
+                                       }
+                                     }, Store
+
+    assert_search "store", ['Costco'], {where: {
+                                         nested: {
+                                           path: 'products',
+                                           where: {
+                                             'name' => 'ProductB',
+                                             'aisle' => 2,
+                                           }
+                                         }
+                                       }
+                                     }, Store
+  end
+
   # other tests
 
   def test_includes

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -235,6 +235,21 @@ class SqlTest < Minitest::Test
                                        }
                                      }, Store
 
+    assert_search "store", ['Amazon', 'Walmart'], {where: {
+                                         nested: {
+                                           path: 'employees',
+                                           where: {
+                                             nested: {
+                                               path: 'employees.reviews',
+                                               where: {
+                                                 name: 'Review C'
+                                               }
+                                             }
+                                           }
+                                         }
+                                       }
+                                     }, Store
+
 
     # With all
     result = Store.search "*", {where:
@@ -272,6 +287,25 @@ class SqlTest < Minitest::Test
                                }
 
     assert_equal result.results.first.name, 'Walmart'
+
+    assert_search "store", ['Walmart'], {where: {
+                                         nested: {
+                                           path: 'employees',
+                                           where: {
+                                             age: {
+                                               lt: 20
+                                             },
+                                             nested: {
+                                               path: 'employees.reviews',
+                                               where: {
+                                                 name: 'Review C'
+                                               }
+                                             }
+                                           }
+                                         }
+                                       }
+                                     }, Store
+
   end
 
   # other tests

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -177,7 +177,10 @@ class SqlTest < Minitest::Test
 
   def test_where_nested
     store [
-      {name: 'Amazon', employees: [Employee.create(name: 'Jim', age: 22, reviews: [Review.create(name: 'Review A')])]},
+      {name: 'Amazon', employees: [
+        Employee.create(name: 'Jim', age: 22, reviews: [Review.create(name: 'Review A')]),
+        Employee.create(name: 'Jamie', age: 32, reviews: [Review.create(name: 'Review C')])
+      ]},
       {name: 'Costco', employees: [Employee.create(name: 'Bob', age: 34, reviews: [Review.create(name: 'Review B')])]},
       {name: 'Walmart', employees: [Employee.create(name: 'Karen', age: 19, reviews: [Review.create(name: 'Review C')])]}
     ], Store
@@ -231,6 +234,44 @@ class SqlTest < Minitest::Test
                                          }
                                        }
                                      }, Store
+
+
+    # With all
+    result = Store.search "*", {where:
+                                 {nested: {
+                                   path: 'employees',
+                                   where: {
+                                     name: 'Jamie'
+                                   }
+                                 }}
+                               }
+
+    assert_equal result.results.first.name, 'Amazon'
+
+    result = Store.search "*", {where:
+                                 {nested: {
+                                   path: 'employees',
+                                   where: {
+                                     name: 'Bob'
+                                   }
+                                 }}
+                               }
+
+    assert_equal result.results.first.name, 'Costco'
+
+    # With range
+    result = Store.search "*", {where:
+                                 {nested: {
+                                   path: 'employees',
+                                   where: {
+                                     age: {
+                                       lt: 20
+                                     }
+                                   }
+                                 }}
+                               }
+
+    assert_equal result.results.first.name, 'Walmart'
   end
 
   # other tests

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -178,11 +178,23 @@ class SqlTest < Minitest::Test
   def test_where_nested
     store [
       {name: 'Amazon', employees: [
-        Employee.create(name: 'Jim', age: 22, reviews: [Review.create(name: 'Review A')]),
-        Employee.create(name: 'Jamie', age: 32, reviews: [Review.create(name: 'Review C')])
+        Employee.create(name: 'Jim', age: 22, reviews: [
+          Review.create(name: 'Review A', stars: 3, comments: [Comment.create(status: 'denied')])
+        ]),
+        Employee.create(name: 'Jamie', age: 32, reviews: [
+          Review.create(name: 'Review C', stars: 5, comments: [Comment.create(status: 'denied')])
+        ])
       ]},
-      {name: 'Costco', employees: [Employee.create(name: 'Bob', age: 34, reviews: [Review.create(name: 'Review B')])]},
-      {name: 'Walmart', employees: [Employee.create(name: 'Karen', age: 19, reviews: [Review.create(name: 'Review C')])]}
+      {name: 'Costco', employees: [
+        Employee.create(name: 'Bob', age: 34, reviews: [
+          Review.create(name: 'Review B', stars: 2, comments: [Comment.create(status: 'approved')])
+        ])
+      ]},
+      {name: 'Walmart', employees: [
+        Employee.create(name: 'Karen', age: 19, reviews: [
+          Review.create(name: 'Review C', stars: 4, comments: [Comment.create(status: 'approved')])
+        ])
+      ]}
     ], Store
 
     assert_search "store", ["Amazon"], {where: {
@@ -298,7 +310,16 @@ class SqlTest < Minitest::Test
                                              nested: {
                                                path: 'employees.reviews',
                                                where: {
-                                                 name: 'Review C'
+                                                 name: 'Review C',
+                                                 stars: {
+                                                   gt: 3
+                                                 },
+                                                 nested: {
+                                                   path: 'employees.reviews.comments',
+                                                   where: {
+                                                     status: 'approved'
+                                                   }
+                                                 }
                                                }
                                              }
                                            }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -563,11 +563,16 @@ class Store
     employees.map{|e| data[:employees] << {
         name: e.try(:name),
         age: e.try(:age),
-        reviews: {
-          name: e.try(:reviews).try(:last).try(:name),
-          stars: e.try(:reviews).try(:last).try(:stars),
-          comments: {
-            status: e.try(:reviews).try(:last).try(:comments).try(:last).try(:status)
+        reviews: e.try(:reviews).collect{ |r|
+          {
+            name: r.try(:name),
+            stars: r.try(:stars),
+            comments: r.comments.collect{ |c|
+              {
+                status: c.try(:status),
+                message: c.try(:message)
+              }
+            }
           }
         }
       }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -467,7 +467,10 @@ class Store
     mappings: {
       store: {
         properties: {
-          name: {type: "keyword"}
+          name: {type: "keyword"},
+          products: {
+            type: 'nested'
+          }
         }
       }
     }
@@ -478,6 +481,15 @@ class Store
 
   def search_routing
     name
+  end
+
+  def search_data
+    serializable_hash.except("id", "_id").merge(
+      products: {
+        name: products.last.try(:name),
+        aisle: products.last.try(:aisle)
+      }
+    )
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -542,14 +542,17 @@ class Store
   end
 
   def search_data
-    serializable_hash.except("id", "_id").merge(
-      employees: {
-        name: employees.last.try(:name),
-        age: employees.last.try(:age),
+    data = {employees: []}
+    employees.map{|e| data[:employees] << {
+        name: e.try(:name),
+        age: e.try(:age),
         reviews: {
-          name: employees.last.try(:reviews).try(:last).try(:name)
+          name: e.try(:reviews).try(:last).try(:name)
         }
       }
+    }
+    serializable_hash.except("id", "_id").merge(
+      data
     )
   end
 end


### PR DESCRIPTION
Ticket ECA-2245

This adds support for nested queries. Since the [nested filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html) is no longer available this uses the [nested query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html). This was originally implemented in [this PR](https://github.com/ankane/searchkick/pull/527) but because the nested filter has changed it is no longer viable. 

The specs are a bit excessive as is but wanted to cover as many nested query scenarios as possible. When pull requesting back into the mainline searchkick gem we can slim down the specs a bit if desired.

An example of some queries like the following should now be supported:
```
User.search('*', where: {
  first_name: 'Derek',
  nested: {
     path: 'property_that_is_mapped_as_nested',
     where: {
         nested_property: 'foo',
         another_nested_property: 'bar'
     }
  }
})
```

```
User.search('*', where: {
  first_name: 'Derek',
  nested: [
    {
       path: 'property_that_is_mapped_as_nested',
       where: {
           nested_property: 'foo',
           another_nested_property: 'bar'
       }
     }, {
       path: 'other_property_that_is_mapped_as_nested',
       where: {
           other_nested_property: 'foo',
           another_nested_property: 'bar'
       }
    }]
})
```

```
User.search('*', where: {
  first_name: 'Derek',
  nested: {
     path: 'first_nested_doc',
     where: {
         nested_property: 'foo'
         nested: {
           path: 'second_nested_doc',
           where: {
              nested_property: 'bar'
              nested: {
                path: 'third_nested_doc',
                where: {
                  nested_property: 'foobar',
                  another_nested_property: 'barfoo'
               }
             }
           }
         }
     }
  }
})
```