### PR TITLE
ASMT-547: Addressing issues to query within adminifi

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -555,8 +555,14 @@ module Searchkick
         bool[:must_not] = must_not if must_not.any?  # exclude
         bool[:should] = should if should.any?        # conversions
 
-        # nested query and does not contain match all
-        if nested && !bool.dig(:must, :match_all)
+        # nested query
+        if nested
+          # If query is nested ensure dis_max queries
+          # is available. This allows processing of JSON
+          # field as nested without adding to mappings
+          unless bool.dig(:must, :dis_max, :queries)
+            bool[:must] = { dis_max: { queries: [] } }
+          end
           bool.dig(:must, :dis_max, :queries) << nested_query(nested, filters)
         end
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -880,7 +880,7 @@ module Searchkick
           filters << {bool: {must_not: where_filters(value)}}
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
-        elsif field == :nested
+        elsif field.to_sym == :nested
           Array.wrap(value).each { |v| filters << nested_filters(v) }
         elsif value.try(:keys).try(:include?, :nested)
           # Handle nested field containing JSON data

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1"
+  VERSION = "3.1.1-everfi.1"
 end

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -411,11 +411,12 @@ class SqlTest < Minitest::Test
 
   def test_json_field
     store [
-      {name: 'Amazon', nested_json: {nested_field: {name: 'test1'}}},
-      {name: 'Costco', nested_json: {nested_field: {name: 'test2'}}},
-      {name: 'Walmart', nested_json: {nested_field: {name: 'test3'}}}
+      {name: 'Amazon', nested_json: {foo: 'bar', nested_field: {name: 'test1'}}},
+      {name: 'Costco', nested_json: {foo: 'boo', nested_field: {name: 'test2'}}},
+      {name: 'Walmart', nested_json: {foo: 'boo', nested_field: {name: 'test3'}}}
     ], Store
 
+    # Flattened dot notation
     result = Store.search "*", { where: {
                                    'nested_json.nested_field.name': 'test1'
                                  }
@@ -423,12 +424,30 @@ class SqlTest < Minitest::Test
 
     assert_equal result.results.first.name, 'Amazon'
 
+    # Directly access nested JSON field
     result = Store.search "*", { where: {
                                    name: 'Amazon',
                                    nested: {
                                      path: 'nested_field',
                                      where: {
-                                        name: 'test1'
+                                       name: 'test1'
+                                     }
+                                   }
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Amazon'
+
+    # Access JSON from field then nested mapping
+    result = Store.search "*", { where: {
+                                   name: 'Amazon',
+                                   nested_json: {
+                                     foo: 'bar',
+                                     nested: {
+                                       path: 'nested_field',
+                                       where: {
+                                         name: 'test1'
+                                       }
                                      }
                                    }
                                  }

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -409,6 +409,34 @@ class SqlTest < Minitest::Test
 
   end
 
+  def test_json_field
+    store [
+      {name: 'Amazon', nested_json: {nested_field: {name: 'test1'}}},
+      {name: 'Costco', nested_json: {nested_field: {name: 'test2'}}},
+      {name: 'Walmart', nested_json: {nested_field: {name: 'test3'}}}
+    ], Store
+
+    result = Store.search "*", { where: {
+                                   'nested_json.nested_field.name': 'test1'
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Amazon'
+
+    result = Store.search "*", { where: {
+                                   name: 'Amazon',
+                                   nested: {
+                                     path: 'nested_field',
+                                     where: {
+                                        name: 'test1'
+                                     }
+                                   }
+                                 }
+                               }
+
+    assert_equal result.results.first.name, 'Amazon'
+  end
+
   def test_nested_json
     store [
       {name: 'Jim', reviews: [Review.create(name: 'Review A')]},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -383,6 +383,7 @@ else
 
   ActiveRecord::Migration.create_table :stores do |t|
     t.string :name
+    t.json :nested_json
   end
 
   ActiveRecord::Migration.create_table :employees do |t|
@@ -542,7 +543,12 @@ class Store
     mappings: {
       store: {
         properties: {
-          name: {type: "keyword"},
+          nested_field: {
+            type: 'nested',
+            properties: {
+              name: {type: 'text'}
+            }
+          },
           employees: {
             type: 'nested',
             properties: {
@@ -595,6 +601,7 @@ class Store
         }
       }
     }
+    data[:nested_field] = nested_json&.dig('nested_field')
     serializable_hash.except("id", "_id").merge(
       data
     )


### PR DESCRIPTION
In order to allow flattened/dot notation of JSON field along with use of nested query this adjusts building of query. Without this change the nested field will need to be placed into mappings. For our use case this is less than ideal. This change allows mappings to remain the same and query against either the nested mapping or the field then mapping.

Example:

```
    # Directly access nested JSON field
    result = Store.search "*", { where: {
         name: 'Amazon',
         nested: {
           path: 'nested_field',
             where: {
               name: 'test1'
              }
            }
          }
        }

     # Access JSON from field then nested mapping
    result = Store.search "*", { where: {
         name: 'Amazon',
         nested_json: {
           nested: {
             path: 'nested_field',
               where: {
                 name: 'test1'
                }
              }
            }
          }
        }
```