### PR TITLE
[CS-3329] Ensure FE can properly generate dynamic filters

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -855,6 +855,10 @@ module Searchkick
 
         field = :_id if field.to_s == "id"
 
+        # This addition ensures FE can properly
+        # create dynamic filters!
+        field = field.to_sym
+
         if field == :or
           value.each do |or_clause|
             filters << {bool: {should: or_clause.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.2.0-everfi.1"
+  VERSION = "3.2.1-everfi.1"
 end

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -157,6 +157,92 @@ class SqlTest < Minitest::Test
     assert_search "frozen", ["Product A"], {fields: ["aisle.name"]}, Speaker
   end
 
+  def test_alternate_boolean_syntax
+    store [
+      {
+        name: 'Walmart', employees: [
+          Employee.create(name: 'Daniel', age: 32),
+          Employee.create(name: 'Kaitlyn', age: 32)
+        ]
+      }
+    ], Store
+
+    result = Store.search('*', {
+      where: {
+        '_and' => [
+          {
+            nested: {
+              path: 'employees',
+              where:  {
+                name: 'Daniel'
+              }
+            }
+          },
+          {
+            nested: {
+              path: 'employees',
+              where: {
+                name: 'Kaitlyn'
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    assert_equal result.results.count, 1
+
+    result = Store.search('*', {
+      where: {
+        '_and' => [
+          {
+            nested: {
+              path: 'employees',
+              where:  {
+                name: 'Daniel'
+              }
+            }
+          },
+          {
+            nested: {
+              path: 'employees',
+              where: {
+                name: 'Charles'
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    assert_equal result.results.count, 0
+
+    result = Store.search('*', {
+      where: {
+        '_or' => [
+          {
+            nested: {
+              path: 'employees',
+              where:  {
+                name: 'Daniel'
+              }
+            }
+          },
+          {
+            nested: {
+              path: 'employees',
+              where: {
+                name: 'Charles'
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    assert_equal result.results.count, 1
+  end
+
   def test_where_multiple_nested
     store [
       {

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -44,10 +44,13 @@ class WhereTest < Minitest::Test
     # _or
     assert_search "product", ["Product A", "Product B", "Product C"], where: {_or: [{in_stock: true}, {store_id: 3}]}
     assert_search "product", ["Product A", "Product B", "Product C"], where: {_or: [{orders_count: [2, 4]}, {store_id: [1, 2]}]}
+    assert_search "product", ["Product A", "Product B", "Product C"], where: {'_or' => [{orders_count: [2, 4]}, {store_id: [1, 2]}]}
     assert_search "product", ["Product A", "Product D"], where: {_or: [{orders_count: 1}, {created_at: {gte: now - 1}, backordered: true}]}
+    assert_search "product", ["Product A", "Product D"], where: {'_or' => [{orders_count: 1}, {created_at: {gte: now - 1}, backordered: true}]}
 
     # _and
     assert_search "product", ["Product A"], where: {_and: [{in_stock: true}, {backordered: true}]}
+    assert_search "product", ["Product A"], where: {'_and' => [{in_stock: true}, {backordered: true}]}
 
     # _not
     assert_search "product", ["Product B", "Product C"], where: {_not: {_or: [{orders_count: 1}, {created_at: {gte: now - 1}, backordered: true}]}}


### PR DESCRIPTION
After testing nested searchkick changes with FE updates... Noticed that due to JSON stringify behavior it isn't possible to produce the symbol needed to produce _and: / _or:

In addition, we previously generated wrong symbol behavior in FE for boolean behavior... and this will address that issue. I will also be making a minor FE modification to the logic to ensure we stick to simple '_and' / '_or' strings to keep dynamic filter generation simple and consistent.