### PR TITLE
ECA-5119: Add indexed_at to search data so we can see when an record was last indexed

### DIFF
--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -11,13 +11,13 @@ module Searchkick
 
     def index_data
       data = record_data
-      data[:data] = search_data
+      data[:data] = timestamped_search_data
       {index: data}
     end
 
     def update_data(method_name)
       data = record_data
-      data[:data] = {doc: search_data(method_name)}
+      data[:data] = {doc: timestamped_search_data(method_name)}
       {update: data}
     end
 
@@ -44,6 +44,12 @@ module Searchkick
       }
       data[:_routing] = record.search_routing if record.respond_to?(:search_routing)
       data
+    end
+
+    def timestamped_search_data(method_name = nil)
+      search_data(method_name).merge(
+        indexed_at: Time.now.utc
+      )
     end
 
     def search_data(method_name = nil)

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.2.0-everfi.1"
+  VERSION = "3.2.0-everfi.2"
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -31,4 +31,21 @@ class ModelTest < Minitest::Test
 
     assert_search "product", ["product a", "product b"]
   end
+
+  def test_search_data_matches
+    store_names ["Product A"]
+    metadata_keys = %w(_index _type _id _score _routing id indexed_at)
+    expected_result_keys = Product.last.search_data.to_hash.stringify_keys.keys + metadata_keys
+    search_result_keys   = Product.search("Product A", load: false).first.to_hash.keys
+    assert_equal expected_result_keys.sort, search_result_keys.sort
+  end
+
+  def test_indexed_at
+    current_time = Time.now
+    Time.stub :now, current_time do
+      store_names ["Product A"]
+      indexed_at = Product.search("Product A", load: false).first.to_hash['indexed_at']
+      assert_equal indexed_at, current_time.strftime('%FT%T.%LZ')
+    end
+  end
 end


### PR DESCRIPTION
https://everfi.atlassian.net/browse/ECA-5119

Adminifi will be bumped to use this version once it merges and the gem is released. I functional tested this locally in adminifi and it works as expected.

A few notes:

* Surprisingly, the repo had no tests around search data, so I did add one, in addition to testing the functionality I changed.
* This uses pure Ruby methods for compatibility if used in non-Rails repos