### PR TITLE
FC-894 Add global refresh mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 ## ! Custom Foundry features presenting in this fork only !
 
+### Global refresh mode
+
+In additional to generic `Searchkick.callbacks(:inline) do; end` now it's possible to set refresh mode for the nested block:
+
+```ruby
+Searchkick.refresh(true) do # accepts `true`, 'false' or `:wait_for`
+  # Foobar
+end
+```
+
 ### Dynamic callbacks mode
 It's possible to specify callbacks mode by lambda, in order to apply very special conditions like
 

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -153,6 +153,21 @@ module Searchkick
     end
   end
 
+  def self.refresh(value)
+    unless block_given?
+      self.refresh_value = value
+      return
+    end
+
+    previous_value = refresh_value
+    begin
+      self.refresh_value = value
+      yield
+    ensure
+      self.refresh_value = previous_value
+    end
+  end
+
   def self.aws_credentials=(creds)
     begin
       require "faraday_middleware/aws_signers_v4"
@@ -221,6 +236,16 @@ module Searchkick
   # private
   def self.callbacks_value=(value)
     Thread.current[:searchkick_callbacks_enabled] = value
+  end
+
+  # private
+  def self.refresh_value
+    Thread.current[:searchkick_refresh_value]
+  end
+
+  # private
+  def self.refresh_value=(value)
+    Thread.current[:searchkick_refresh_value] = value
   end
 
   # private

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -15,7 +15,7 @@ module Searchkick
       items = @queued_items
       @queued_items = []
       if items.any?
-        response = Searchkick.client.bulk(body: items, refresh: true_refresh)
+        response = Searchkick.client.bulk(body: items, refresh: Searchkick.refresh_value || true_refresh)
         if response["errors"]
           first_with_error = response["items"].map do |item|
             (item["index"] || item["delete"] || item["update"])

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "4.0.0.everfi.1"
+  VERSION = "3.1.1.everfi.2.0.0"
 end


### PR DESCRIPTION
[FC-894](https://everfi.atlassian.net/browse/FC-894)

In additional to generic `Searchkick.callbacks(:inline) do; end` now it's possible to set refresh mode for the nested block:

```ruby
Searchkick.refresh(true) do # accepts `true`, 'false' or `:wait_for`
  # Foobar
end
```

Tests will be written within `everfi_json_api` gem upon the usage.