### PR TITLE
FC-894 Try keeping `pre` suffix in gem version

### DIFF
--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.everfi.2.0.0"
+  VERSION = "3.1.1.pre.everfi.2.0.0"
 end


### PR DESCRIPTION
Bundler is getting crazy without `pre` version suffix (