### PR TITLE
ECA-8600 Fix bulkified versioned reindexing

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -143,7 +143,12 @@ module Searchkick
       begin
         self.callbacks_value = value
         result = yield
-        indexer.perform if callbacks_value == :bulk
+        begin
+          indexer.perform if callbacks_value == :bulk
+        rescue Searchkick::ImportError => e
+          # Just ignore versioning error
+          raise unless e.message.include?('version_conflict_engine_exception')
+        end
         result
       ensure
         self.callbacks_value = previous_value

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.pre.everfi.2.0.0"
+  VERSION = "3.1.1.pre.everfi.2.0.1"
 end


### PR DESCRIPTION
[ECA-8600](https://everfi.atlassian.net/browse/ECA-8600)

It's normal and expected to ignore ES versioning errors, considering that the largest version number will eventually bring the most actual record state to the index. We are ignoring these errors during inline reindexing (see `Searchkick::ThreadSafeIndexer#queue_record_data_array`) but missed to rescue the same within bulk reindexing - which used for synchronous reindexing on demand.

Full-weight integration test will be added to Adminifi repo.