### PR TITLE
FC-1067 performance async preloads includes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchkick (3.1.1.pre.everfi.2.1.0)
+    searchkick (3.1.1.pre.everfi.2.1.1)
       activemodel (>= 4.2)
       elasticsearch (>= 5, < 7)
       hashie

--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -90,6 +90,16 @@ module Searchkick
         # TODO expire Redis key
         primary_key = scope.primary_key
 
+        # Improved performance of async full reindex
+        # We do not want to leverage includes or preload
+        # prior to full async reindex since only the id
+        # is required for the job and any preloaded
+        # associations is a waste of resources.
+        #
+        # Also addressed in upstream
+        # https://github.com/ankane/searchkick/issues/1325
+        scope = scope.select(primary_key).except(:includes, :preload)
+
         starting_id =
           begin
             scope.minimum(primary_key)

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.pre.everfi.2.1.0"
+  VERSION = "3.1.1.pre.everfi.2.1.1"
 end


### PR DESCRIPTION
[Ticket](https://everfi.atlassian.net/browse/FC-1067?filter=-1)

When we issue a full async reindex we do not want to utilize the
includes or the preloads. Only the ID (primary key) is required to
reindex async so any additional loading of associations is useless.

Example where preload came from in adminifi: https://github.com/EverFi/adminifi/blob/develop/app/models/user.rb#L90

Example trace before (with preload impacting performance)
```
ActiveRecord -- User Load -- { :sql => "SELECT * FROM \"users\" WHERE \"users\".\"id\" > $1 ORDER BY \"users\".\"id\" ASC LIMIT $2", :binds => { :id => "fe37366c-8970-4c12-b4a3-045c19cf1275", :limit => 200 }, :allocations => 24, :cached => nil }
2021-12-21 11:47:41.461486 D [35492:11260] (0.660ms) ActiveRecord -- RosterUser Load
2021-12-21 11:47:41.475754 D [35492:11260] (0.235ms) ActiveRecord -- Category Load -- { :sql => "SELECT \"categories\".* FROM \"categories\" WHERE \"categories\".\"id\" = $1", :binds => { :id => 6 }, :allocations => 23, :cached => nil }
2021-12-21 11:47:41.477874 I [35492:11260] Rails -- Enqueued Searchkick::BulkReindexJob
```

After we just have the User query
```
2021-12-21 12:19:45.945210 D [37635:11240] (0.793ms) ActiveRecord -- User Load -- { :sql => "SELECT \"users\".\"id\" FROM \"users\" WHERE \"users\".\"id\" > $1 ORDER BY \"users\".\"id\" ASC LIMIT $2", :binds => { :id => "ebc51b0c-cb2c-4301-a60e-958338e0dea4", :limit => 200 }, :allocations => 24, :cached => nil }
2021-12-21 12:19:45.971173 I [37635:11240] Rails -- Enqueued Searchkick::BulkReindexJob
```

This has already been addressed in upstream.

https://github.com/ankane/searchkick/issues/1325

https://github.com/ankane/searchkick/commit/610937f8c16f504e96418adedf192b0c98a09ce9