### PR TITLE
ECA-8731 Set large initial version number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchkick (3.1.1.pre.everfi.2.1.1)
+    searchkick (3.1.1.pre.everfi.2.2.0)
       activemodel (>= 4.2)
       elasticsearch (>= 5, < 7)
       hashie

--- a/lib/searchkick/index_version.rb
+++ b/lib/searchkick/index_version.rb
@@ -1,5 +1,6 @@
 module Searchkick
   class IndexVersion < ::ActiveRecord::Base
+    INITIAL_VERSION = 10_000
     self.table_name = 'searchkick_index_versions'
 
     class << self
@@ -21,7 +22,8 @@ module Searchkick
         new_records_attributes = ids.map { |id|
           {
             resource_type: model.name,
-            resource_id: id
+            resource_id: id,
+            version: INITIAL_VERSION
           }
         }
 
@@ -33,7 +35,7 @@ module Searchkick
 
         result_sets = connection.execute <<~SQL
           UPDATE #{table_name}
-          SET version = version + 1
+          SET version = GREATEST(version, #{INITIAL_VERSION}) + 1
           WHERE resource_type = #{connection.quote(model.name)}
             AND resource_id IN (#{quoted_ids})
           RETURNING resource_id, version

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.pre.everfi.2.1.1"
+  VERSION = "3.1.1.pre.everfi.2.2.0"
 end


### PR DESCRIPTION
[ECA-8731](https://everfi.atlassian.net/browse/ECA-8731)

Set's the large initial version number in order to overcome the value which might be populated by ES itself before we switched to thread-safe reindexing. This way the full model reindexing is no longer strictly required.

All the tests will be added to Adminifi repo.