### PR TITLE
QAOPS-5999 autoload zeitwerk searchkick reindex all task

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @everfi/gem-upgrades

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchkick (3.1.1.pre.everfi.2.2.0)
+    searchkick (3.1.1.pre.everfi.2.2.1)
       activemodel (>= 4.2)
       elasticsearch (>= 5, < 7)
       hashie
@@ -51,25 +51,29 @@ GEM
     erubi (1.10.0)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    faraday (1.8.0)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     ffi (1.15.4)
     gemoji (3.0.1)
     gemoji-parser (1.3.1)
@@ -119,6 +123,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  x86_64-darwin-18
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/searchkick/tasks.rb
+++ b/lib/searchkick/tasks.rb
@@ -17,7 +17,14 @@ namespace :searchkick do
     namespace :reindex do
       desc "reindex all models"
       task all: :environment do
-        Rails.application.eager_load!
+        # eager load models to populate Searchkick.models
+        if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+          # fix for https://github.com/rails/rails/issues/37006
+          Zeitwerk::Loader.eager_load_all
+        else
+          Rails.application.eager_load!
+        end
+
         Searchkick.models.each do |model|
           puts "Reindexing #{model.name}..."
           model.reindex

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.pre.everfi.2.2.0"
+  VERSION = "3.1.1.pre.everfi.2.2.1"
 end


### PR DESCRIPTION
[Ticket](https://everfi.atlassian.net/browse/QAOPS-5999?filter=-1)

We are currently receiving a subset of searchkick models to reindex when
invoking the searchkick:reindex:all rake task. This is due to
autoloading changes. In order to resolve the issue, we're updating the
rake task to handle for zeitwerk to ensure all models will be loaded and
subsequently reindexed.

This is the current implementation on searchkick master and I've confirmed this does pick up all expected models in console.
See https://github.com/EverFi/searchkick/blob/master/lib/searchkick/tasks.rb#L16-L28