### PR TITLE
Fix ES initialiser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchkick (3.1.1.pre.everfi.2.3.0)
+    searchkick (3.1.1.pre.everfi.2.3.1)
       activemodel (>= 4.2)
       elasticsearch (>= 5, < 7)
       hashie

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -272,7 +272,10 @@ module Searchkick
   end
 
   def self.unified_mappings(name, mappings)
-    return mappings unless Searchkick.server_below?("7.0.0")
+    begin
+      return mappings unless Searchkick.server_below?("7.0.0")
+    rescue Faraday::ConnectionFailed # fallback to ES6, might be helpful for non-env tasks like `rake assets:precompile`
+    end
 
     { name => mappings }
   end

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "3.1.1.pre.everfi.2.3.0"
+  VERSION = "3.1.1.pre.everfi.2.3.1"
 end


### PR DESCRIPTION
Falls back to ES6 interface for non-env tasks like `rake assets:precompile`.

Indeed, check for ES version is meaning the call to ES server - which might be not set.