### PR TITLE
Redis change from int to bool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    searchkick (5.0.4.pre.everfi.1.0.1)
+    searchkick (5.0.4.pre.everfi.1.1.0)
       activemodel (>= 5.2)
       hashie
 

--- a/lib/searchkick/relation_indexer.rb
+++ b/lib/searchkick/relation_indexer.rb
@@ -46,7 +46,7 @@ module Searchkick
     end
 
     def batch_completed(batch_id)
-      Searchkick.with_redis { |r| r.srem(batches_key, batch_id) }
+      Searchkick.with_redis { |r| r.srem?(batches_key, batch_id) }
     end
 
     private
@@ -134,7 +134,7 @@ module Searchkick
     end
 
     def batch_job(class_name, batch_id, record_ids)
-      Searchkick.with_redis { |r| r.sadd(batches_key, batch_id) }
+      Searchkick.with_redis { |r| r.sadd?(batches_key, batch_id) }
       Searchkick::BulkReindexJob.perform_later(
         class_name: class_name,
         index_name: index.name,

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "5.0.4.pre.everfi.1.0.1"
+  VERSION = "5.0.4.pre.everfi.1.1.0"
 end


### PR DESCRIPTION
Starting in gem update 4.8.0, `sadd` and `srem` need to be called as booleans `sadd?` and `srem?` when adding or removing one value to a set https://github.com/redis/redis-rb/blob/4.x/CHANGELOG.md#480